### PR TITLE
sees to me new erlang (23.X) version fails with this erl_interface param

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -34,7 +34,7 @@ endif
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei -lkrb5 -lsasl2
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei -lkrb5 -lsasl2
 LDFLAGS += -shared
 
 # Verbosity.


### PR DESCRIPTION
based on docs it should be deprecated only, but I have error:
```
/usr/bin/ld: cannot find -lerl_interface
collect2: error: ld returned 1 exit status
```