### PR TITLE
fix: set fail_on_load_if_load_unsuccessful defaults to false

### DIFF
--- a/src/sasl_auth.app.src
+++ b/src/sasl_auth.app.src
@@ -1,6 +1,6 @@
 {application, sasl_auth, [
     {description, "Simple helper for SASL GSSAPI auth mechanism support in erlang applications"},
-    {vsn, "2.0.0"},
+    {vsn, "2.0.1"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {env, []},

--- a/src/sasl_auth.erl
+++ b/src/sasl_auth.erl
@@ -133,10 +133,7 @@ init() ->
             _ ->
                 ok
         end,
-    CanFail = application:get_env(sasl_auth,
-                                  fail_on_load_if_load_unsuccessful,
-                                  true),
-    case CanFail of
+    case application:get_env(sasl_auth, fail_on_load_if_load_unsuccessful, false) of
         _ when RetVal =:= ok ->
             ok;
         true ->


### PR DESCRIPTION
Set fail_on_load_if_load_unsuccessful to false as when upgrading from
old emqx version the erlang vm would crash on `code:load_binary/3`.

See https://github.com/erlang/otp/blob/7bf7f01683acf9b8f09bd8c7331854a9abc17f7d/lib/sasl/src/release_handler_1.erl#L353 for details.