### PR TITLE
Fix segfault possibilities

### DIFF
--- a/c_src/sasl_auth.c
+++ b/c_src/sasl_auth.c
@@ -17,10 +17,11 @@
 #define UNUSED(x) x
 #endif
 
-ERL_NIF_TERM ATOM_OK;
-ERL_NIF_TERM ATOM_ERROR;
-ERL_NIF_TERM ATOM_OOM;
-ERL_NIF_TERM ATOM_UNKNOWN;
+static ERL_NIF_TERM ATOM_OK;
+static ERL_NIF_TERM ATOM_ERROR;
+static ERL_NIF_TERM ATOM_OOM;
+static ERL_NIF_TERM ATOM_UNKNOWN;
+static ERL_NIF_TERM ATOM_NOT_CONTROLLING_PROCESS;
 
 #define OK_TUPLE(env, ret) enif_make_tuple2(env, ATOM_OK, ret)
 #define SASL_STEP_TUPLE(env, code, out, outlen)                                                    \
@@ -32,17 +33,86 @@ ERL_NIF_TERM ATOM_UNKNOWN;
 typedef struct {
     sasl_conn_t* conn;
     sasl_callback_t callbacks[16];
+    unsigned char* principal;
+    unsigned char* service;
+    unsigned char* host;
+    ErlNifPid controlling_process;
+    ErlNifMutex* controller_lock;
     int mech_set;
 } sasl_state_t;
 
 // SASL connection state
 static ErlNifResourceType* sasl_resource = NULL;
 
-static void destroy_resource(ErlNifEnv* UNUSED(env), sasl_state_t* res)
+static void destroy_resource(ErlNifEnv* UNUSED(env), sasl_state_t* state)
 {
-    if (res != NULL) {
-        sasl_dispose(&res->conn);
+    if (state != NULL) {
+        if (state->conn != NULL) {
+            if (state->controller_lock != NULL) {
+                enif_mutex_lock(state->controller_lock);
+            }
+
+            sasl_dispose(&state->conn);
+
+            if (state->controller_lock != NULL) {
+                enif_mutex_unlock(state->controller_lock);
+            }
+        }
+
+        if (state->controller_lock != NULL) {
+            enif_mutex_destroy(state->controller_lock);
+        }
+
+        if (state->principal != NULL) {
+            enif_free(state->principal);
+        }
+
+        if (state->service != NULL) {
+            enif_free(state->service);
+        }
+
+        if (state->host != NULL) {
+            enif_free(state->host);
+        }
     }
+}
+
+static void* sasl_mutex_alloc(void) { return enif_mutex_create("sasl_auth.callback"); }
+
+static int sasl_mutex_lock(ErlNifMutex* mutex)
+{
+    int ret;
+
+    if (mutex == NULL) {
+        ret = 1;
+    } else {
+        enif_mutex_lock(mutex);
+        ret = 0;
+    }
+
+    return ret;
+}
+
+static int sasl_mutex_unlock(ErlNifMutex* mutex)
+{
+    int ret;
+    if (mutex == NULL) {
+        ret = 1;
+    } else {
+        enif_mutex_unlock(mutex);
+        ret = 0;
+    }
+
+    return ret;
+}
+
+static void sasl_mutex_free(ErlNifMutex* mutex)
+{
+    if (mutex != NULL) {
+        enif_mutex_destroy(mutex);
+    }
+
+    return;
 }
 
 static ErlNifResourceType* init_resource_type(ErlNifEnv* env)
@@ -57,9 +127,13 @@ static int load(ErlNifEnv* env, void** UNUSED(priv), ERL_NIF_TERM UNUSED(info))
     ATOM_ERROR = enif_make_atom(env, "error");
     ATOM_OOM = enif_make_atom(env, "out_of_memory");
     ATOM_UNKNOWN = enif_make_atom(env, "unknown");
+    ATOM_NOT_CONTROLLING_PROCESS = enif_make_atom(env, "not_controlling_process");
 
     sasl_resource = init_resource_type(env);
     int result;
+    sasl_set_mutex((sasl_mutex_alloc_t*)&sasl_mutex_alloc, (sasl_mutex_lock_t*)&sasl_mutex_lock,
+        (sasl_mutex_unlock_t*)&sasl_mutex_unlock, (sasl_mutex_free_t*)&sasl_mutex_free);
+
     result = sasl_client_init(NULL);
     return !sasl_resource && !(result == SASL_OK);
 }
@@ -74,6 +148,19 @@ static void unload(ErlNifEnv* UNUSED(env), void* UNUSED(priv))
 {
     sasl_done();
     return;
+}
+
+static unsigned char* copy_bin(ErlNifBinary bin)
+{
+    unsigned char* new;
+    unsigned char* old_data = bin.data;
+    new = enif_alloc(bin.size);
+    if (new == NULL) {
+        return NULL;
+    } else {
+        memcpy(new, old_data, bin.size);
+        return new;
+    }
 }
 
 static ERL_NIF_TERM str_to_bin(ErlNifEnv* env, const char* string, unsigned long len)
@@ -114,6 +201,23 @@ static int sasl_cyrus_cb_getsimple(void* context, int id, const char** result, u
     return *result ? SASL_OK : SASL_FAIL;
 }
 
+static int sasl_auth_process_check(ErlNifEnv* env, sasl_state_t* state)
+{
+    int is_controlling_process;
+    ErlNifPid current_process;
+
+    enif_self(env, &current_process);
+
+    enif_mutex_lock(state->controller_lock);
+
+    is_controlling_process = enif_is_identical(
+        enif_make_pid(env, &current_process), enif_make_pid(env, &state->controlling_process));
+
+    enif_mutex_unlock(state->controller_lock);
+
+    return is_controlling_process;
+}
+
 static ERL_NIF_TERM sasl_cli_new(ErlNifEnv* env, int UNUSED(argc), const ERL_NIF_TERM argv[])
 {
     ErlNifBinary service, host, principal;
@@ -134,24 +238,56 @@ static ERL_NIF_TERM sasl_cli_new(ErlNifEnv* env, int UNUSED(argc), const ERL_NIF
 
     state->mech_set = 0;
 
+    enif_self(env, &state->controlling_process);
+
+    state->controller_lock = enif_mutex_create("sasl_auth.controller_lock");
+
+    state->principal = copy_bin(principal);
+    if (state->principal == NULL) {
+        return ERROR_TUPLE(env, ATOM_OOM);
+    }
+
+    state->service = copy_bin(service);
+    if (state->service == NULL) {
+        return ERROR_TUPLE(env, ATOM_OOM);
+    }
+
+    state->host = copy_bin(host);
+
+    if (state->host == NULL) {
+        return ERROR_TUPLE(env, ATOM_OOM);
+    }
+
     sasl_callback_t callbacks[16]
-        = { { SASL_CB_USER, (void*)sasl_cyrus_cb_getsimple, principal.data },
-              { SASL_CB_AUTHNAME, (void*)sasl_cyrus_cb_getsimple, principal.data },
+        = { { SASL_CB_USER, (void*)sasl_cyrus_cb_getsimple, state->principal },
+              { SASL_CB_AUTHNAME, (void*)sasl_cyrus_cb_getsimple, state->principal },
               { SASL_CB_LIST_END } };
 
     memcpy(state->callbacks, callbacks, sizeof(callbacks));
 
     int result;
-    result = sasl_client_new((const char*)service.data, (const char*)host.data, NULL, NULL,
+    enif_mutex_lock(state->controller_lock);
+
+    result = sasl_client_new((const char*)state->service, (const char*)state->host, NULL, NULL,
         state->callbacks, 0, &state->conn);
+
+    enif_mutex_unlock(state->controller_lock);
+
     ERL_NIF_TERM term = enif_make_resource(env, state);
 
     switch (result) {
     case SASL_OK:
         enif_release_resource(state);
-
         return OK_TUPLE(env, term);
     default:
+        enif_free(state->principal);
+        state->principal = NULL;
+        enif_free(state->service);
+        state->service = NULL;
+        enif_free(state->host);
+        state->host = NULL;
+        enif_mutex_destroy(state->controller_lock);
+        state->controller_lock = NULL;
         enif_release_resource(state);
         return ERROR_TUPLE(env, enif_make_int(env, result));
     }
@@ -166,12 +302,17 @@ static ERL_NIF_TERM sasl_list_mech(ErlNifEnv* env, int UNUSED(argc), const ERL_N
 
     if ((!enif_get_resource(env, argv[0], sasl_resource, (void**)&state))) {
         return enif_make_badarg(env);
+    } else if (!sasl_auth_process_check(env, state)) {
+        return enif_raise_exception(env, ATOM_NOT_CONTROLLING_PROCESS);
     }
+
+    enif_mutex_lock(state->controller_lock);
 
     res = sasl_listmech(state->conn, NULL, NULL, " ", NULL, &avail_mechs, NULL, NULL);
 
-    if (SASL_OK == res) {
+    enif_mutex_unlock(state->controller_lock);
 
+    if (SASL_OK == res) {
         return OK_TUPLE(env, str_to_bin(env, avail_mechs, strlen(avail_mechs)));
     } else {
         return ERROR_TUPLE(
@@ -188,9 +329,15 @@ static ERL_NIF_TERM sasl_cli_start(ErlNifEnv* env, int UNUSED(argc), const ERL_N
 
     if ((!enif_get_resource(env, argv[0], sasl_resource, (void**)&state))) {
         return enif_make_badarg(env);
+    } else if (!sasl_auth_process_check(env, state)) {
+        return enif_raise_exception(env, ATOM_NOT_CONTROLLING_PROCESS);
     }
 
+    enif_mutex_lock(state->controller_lock);
+
     result = sasl_client_start(state->conn, "GSSAPI", NULL, &out, &outlen, &mech);
+
+    enif_mutex_unlock(state->controller_lock);
 
     ERL_NIF_TERM ret;
     if (SASL_CONTINUE == result) {
@@ -212,19 +359,31 @@ static ERL_NIF_TERM sasl_cli_step(ErlNifEnv* env, int UNUSED(argc), const ERL_NI
     if ((!enif_get_resource(env, argv[0], sasl_resource, (void**)&state))
         || (!enif_inspect_binary(env, argv[1], &challenge))) {
         return enif_make_badarg(env);
+    } else if (!sasl_auth_process_check(env, state)) {
+        return enif_raise_exception(env, ATOM_NOT_CONTROLLING_PROCESS);
     }
 
     int result = 0;
     const char* out;
     unsigned int outlen;
+    unsigned char* challenge_in = NULL;
     ERL_NIF_TERM ret;
 
     sasl_interact_t* interact = NULL;
 
-    if (state->mech_set) {
+    if (state->mech_set && state->conn) {
+        challenge_in = copy_bin(challenge);
+        if (challenge_in == NULL) {
+            return ERROR_TUPLE(env, ATOM_OOM);
+        }
+        enif_mutex_lock(state->controller_lock);
+
         result
-            = sasl_client_step(state->conn, challenge.size > 0 ? (const char*)challenge.data : NULL,
+            = sasl_client_step(state->conn, challenge.size > 0 ? (const char*)challenge_in : NULL,
                 (unsigned int)challenge.size, &interact, &out, &outlen);
+
+        enif_mutex_unlock(state->controller_lock);
+
         switch (result) {
         case SASL_OK:
             ret = SASL_STEP_TUPLE(env, result, out, (unsigned long)outlen);
@@ -237,9 +396,43 @@ static ERL_NIF_TERM sasl_cli_step(ErlNifEnv* env, int UNUSED(argc), const ERL_NI
             ret = SASL_ERROR_TUPLE(env, state, result);
         }
     } else {
+
         ret = ERROR_TUPLE(
             env, enif_make_tuple2(env, enif_make_int(env, -4), str_to_bin(env, "No MECH set", 12)));
     }
+    enif_free(challenge_in);
+    return ret;
+}
+
+static ERL_NIF_TERM sasl_cli_done(ErlNifEnv* env, int UNUSED(argc), const ERL_NIF_TERM argv[])
+{
+    sasl_state_t* state;
+    ERL_NIF_TERM ret;
+
+    if ((!enif_get_resource(env, argv[0], sasl_resource, (void**)&state))) {
+        return enif_make_badarg(env);
+    } else if (!sasl_auth_process_check(env, state)) {
+        return enif_raise_exception(env, ATOM_NOT_CONTROLLING_PROCESS);
+    }
+
+    enif_mutex_lock(state->controller_lock);
+    sasl_dispose(&state->conn);
+    enif_mutex_unlock(state->controller_lock);
+    state->conn = NULL;
+
+    enif_mutex_destroy(state->controller_lock);
+    state->controller_lock = NULL;
+
+    enif_free(state->principal);
+    state->principal = NULL;
+
+    enif_free(state->host);
+    state->host = NULL;
+
+    enif_free(state->service);
+    state->service = NULL;
+
+    ret = ATOM_OK;
     return ret;
 }
 
@@ -248,6 +441,8 @@ static ERL_NIF_TERM sasl_kinit(ErlNifEnv* env, int UNUSED(argc), const ERL_NIF_T
 
     ErlNifBinary keytab;
     ErlNifBinary principal_in;
+    unsigned char* principal_mut = NULL;
+    unsigned char* keytab_in = NULL;
     ERL_NIF_TERM ret;
     ERL_NIF_TERM error_tag;
     ERL_NIF_TERM error_code;
@@ -271,17 +466,26 @@ static ERL_NIF_TERM sasl_kinit(ErlNifEnv* env, int UNUSED(argc), const ERL_NIF_T
             || !enif_inspect_binary(env, argv[1], &principal_in)))
         return enif_make_badarg(env);
 
+    principal_mut = copy_bin(principal_in);
+    if (principal_mut == NULL) {
+        return ERROR_TUPLE(env, ATOM_OOM);
+    }
+    keytab_in = copy_bin(keytab);
+    if (keytab_in == NULL) {
+        return ERROR_TUPLE(env, ATOM_OOM);
+    }
+
     if ((error = krb5_init_context(&context)) != 0) {
         tag = "krb5_parse_context";
         goto kinit_finish;
     }
 
-    if ((error = krb5_parse_name(context, (const char*)principal_in.data, &principal)) != 0) {
+    if ((error = krb5_parse_name(context, (const char*)principal_mut, &principal)) != 0) {
         tag = "krb5_parse_name";
         goto kinit_finish;
     }
 
-    if ((error = krb5_kt_resolve(context, (const char*)keytab.data, &kt_handle)) != 0) {
+    if ((error = krb5_kt_resolve(context, (const char*)keytab_in, &kt_handle)) != 0) {
         tag = "krb5_kt_resolve";
         goto kinit_finish;
     }
@@ -344,6 +548,9 @@ kinit_finish:
         krb5_get_init_creds_opt_free(context, options);
     }
     krb5_free_context(context);
+
+    enif_free(principal_mut);
+    enif_free(keytab_in);
     return ret;
 }
 
@@ -352,6 +559,7 @@ static ErlNifFunc nif_funcs[]
           { "sasl_listmech", 1, sasl_list_mech, ERL_NIF_DIRTY_JOB_CPU_BOUND },
           { "sasl_client_start", 1, sasl_cli_start, ERL_NIF_DIRTY_JOB_CPU_BOUND },
           { "sasl_client_step", 2, sasl_cli_step, ERL_NIF_DIRTY_JOB_CPU_BOUND },
+          { "sasl_client_done", 1, sasl_cli_done, ERL_NIF_DIRTY_JOB_CPU_BOUND },
           { "sasl_kinit", 2, sasl_kinit, ERL_NIF_DIRTY_JOB_CPU_BOUND } };
 
 ERL_NIF_INIT(sasl_auth, nif_funcs, &load, NULL, &upgrade, &unload)

--- a/src/sasl_auth.app.src
+++ b/src/sasl_auth.app.src
@@ -1,6 +1,6 @@
 {application, sasl_auth, [
     {description, "Simple helper for SASL GSSAPI auth mechanism support in erlang applications"},
-    {vsn, "2.0.2"},
+    {vsn, "2.1.0"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {env, []},

--- a/src/sasl_auth.erl
+++ b/src/sasl_auth.erl
@@ -11,7 +11,8 @@
     client_new/3,
     client_listmech/1,
     client_start/1,
-    client_step/2
+    client_step/2,
+    client_done/1
 ]).
 -on_load(init/0).
 
@@ -198,6 +199,10 @@ client_step(State, Token) ->
             {error, {code_to_atom(Code), strip_null_terminate(Detail)}}
     end.
 
+-spec client_done(state()) -> ok.
+client_done(State) ->
+    sasl_client_done(State).
+
 code_to_atom(Code) ->
     maps:get(Code, ?SASL_CODES, unknown).
 
@@ -221,6 +226,8 @@ sasl_listmech(_State) -> not_loaded(?LINE).
 sasl_client_start(_State) -> not_loaded(?LINE).
 
 sasl_client_step(_State, _Token) -> not_loaded(?LINE).
+
+sasl_client_done(_State) -> not_loaded(?LINE).
 
 not_loaded(Line) ->
     erlang:nif_error(


### PR DESCRIPTION
Resolves #27 

This PR addresses potential segfault possibilities. Recently, I encountered a segfault in production. Reproducing this is extremely difficult (non-deterministic), such that I took a proverbial sledge hammer to the code to eliminate any potential segfault possibility. The changes within this commit resulted in no more segmentation faults. 


The behavior just up to a segfault through debug logging showed that at some point memory _seemed_ to be corrupted, such that a pointer for the principal winded up pointing to garbage. Specifically, the principal value (pointer) placed into a callback structure which resides in the sasl context is fetched by a callback we provide, eventually the callback returns a garbage value. cyrus-sasl attempts to validate the value, and believes it to be an all white space username (the value is usually a few bytes, and contains no `@` char) [here](https://github.com/cyrusimap/cyrus-sasl/blob/7a6b45b177070198fed0682bea5fa87c18abb084/lib/canonusr.c#L355), when this happens the value that's depended on [here](https://github.com/cyrusimap/cyrus-sasl/blob/7a6b45b177070198fed0682bea5fa87c18abb084/plugins/gssapi.c#L2063) is not set and invalid memory access occurs. This is the rough summary, but I can potentially expand on this more. 

The conditions for the segfault are thus : 

1. Linux with cyrus-sasl version 2.1.27 to 2.1.28 
1. Erlang/OTP 25 - 26 
1. The usage of super carrier with a large amount of memory in play (40GB to 500GB) 
1. Continuously starting and stopping of brod client(s) (i.e., every few minutes or less)
1.  A fair number of active processes in erts (tens of thousands at least). 

In sum : 

1. Do not share binary argument pointers with cyrus-sasl 
1. Do not allow multiple processes to share a context via a controlling process lock check 
1. Use sasl_mutex callbacks recommended per cyrus-sasl 
1. Wrap all calls to cyrus-sasl with mutexes to guard against global state utilization internally in cyrus-sasl 


The mutexes at this point are the most dubious per the addition of a lock to prevent multiple processes from sharing a context. However, it still may be prudent. 