### PR TITLE
refactor: use MEMORY type cache

### DIFF
--- a/scripts/int-test.sh
+++ b/scripts/int-test.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 KRB5_IMAGE='sasl_auth_dockerfile.ubuntu22.04'
-ERLANGE_IMAGE='ghcr.io/emqx/emqx-builder/5.3-9:1.15.7-26.2.5-3-ubuntu20.04'
+ERLANGE_IMAGE='ghcr.io/emqx/emqx-builder/5.3-9:1.15.7-26.2.5-3-ubuntu22.04'
 #ERLANGE_IMAGE="$KRB5_IMAGE"
 NET='example.com'
 REALM='EXAMPLE.COM'

--- a/scripts/int_test.erl
+++ b/scripts/int_test.erl
@@ -20,6 +20,7 @@ run_cli(I) ->
     Service = env("SERVICE"),
     maybe
         ok = sasl_auth:kinit("cli.keytab", env("CLI_PRINC")),
+        io:format("done kinit~n", []),
         {ok, C} ?= sasl_auth:client_new(Service, env("SRV"), env("CLI_PRINC"), env("CLI_NAME")),
         Pid = wait_for_server(I),
         {ok, AvaialbeMecs} ?= sasl_auth:client_listmech(C),

--- a/scripts/int_test.erl
+++ b/scripts/int_test.erl
@@ -19,7 +19,7 @@ do_start(I) ->
 run_cli(I) ->
     Service = env("SERVICE"),
     maybe
-        ok = sasl_auth:kinit("cli.keytab", env("CLI_PRINC")),
+        ok = sasl_auth:kinit("cli.keytab", env("CLI_PRINC"), "MEMORY:test"),
         io:format("done kinit~n", []),
         {ok, C} ?= sasl_auth:client_new(Service, env("SRV"), env("CLI_PRINC"), env("CLI_NAME")),
         Pid = wait_for_server(I),

--- a/src/sasl_auth.erl
+++ b/src/sasl_auth.erl
@@ -65,6 +65,7 @@
 -type state() :: reference().
 -type keytab_path() :: file:filename_all().
 -type principal() :: string() | binary().
+-type ccname() :: string() | binary().
 -type service_name() :: string() | binary().
 -type host() :: string() | binary().
 -type user() :: string() | binary().
@@ -159,12 +160,24 @@ init() ->
             ok
     end.
 
--spec kinit(KeyTabPath :: keytab_path(), Principal :: principal()) ->
+%% @doc Initialize credentials from a keytab file and principal.
+%% It makes use of the per Erlang node static MEMORY type ccache.
+-spec kinit(keytab_path(), principal()) ->
     ok | {error, {binary(), integer(), binary()}}.
 kinit(KeyTabPath, Principal) ->
     Ccname = ccname(),
     kinit(KeyTabPath, Principal, Ccname).
 
+%% @doc Initialize credentials from a keytab file and principal.
+%% The CCname is provided for application's flexibility to decide
+%% which credentials cache type or name to use.
+%% e.g. `FILE:/tmp/krb5cc_mycache' or `MEMORY:krbcc5_mycache'
+%%
+%% CAUTION: Changing credentials cache name at runtime is not tested!
+%% CAUTION: There is currently a lack of call to krb5_cc_destroy, creating
+%%          many caches at runtime may lead to memory leak.
+-spec kinit(keytab_path(), principal(), ccname()) ->
+    ok | {error, {binary(), integer(), binary()}}.
 kinit(KeyTabPath, Principal, Ccname) ->
     sasl_kinit(
         null_terminate(KeyTabPath),

--- a/src/sasl_auth.erl
+++ b/src/sasl_auth.erl
@@ -8,6 +8,7 @@
 -export([
     init/0,
     kinit/2,
+    kinit/3,
     client_new/3,
     client_new/4,
     client_listmech/1,
@@ -161,7 +162,15 @@ init() ->
 -spec kinit(KeyTabPath :: keytab_path(), Principal :: principal()) ->
     ok | {error, {binary(), integer(), binary()}}.
 kinit(KeyTabPath, Principal) ->
-    sasl_kinit(null_terminate(KeyTabPath), null_terminate(Principal)).
+    Ccname = ccname(),
+    kinit(KeyTabPath, Principal, Ccname).
+
+kinit(KeyTabPath, Principal, Ccname) ->
+    sasl_kinit(
+        null_terminate(KeyTabPath),
+        null_terminate(Principal),
+        null_terminate(Ccname)
+    ).
 
 %% @doc Initialize a client context. User client's principal as client's username.
 %% This is the default behaviour before version 2.1.1, however may not work when
@@ -303,7 +312,7 @@ krb5_kt_default_name() -> sasl_krb5_kt_default_name().
 
 sasl_krb5_kt_default_name() -> not_loaded(?LINE).
 
-sasl_kinit(_, _) -> not_loaded(?LINE).
+sasl_kinit(_KeyTab, _Principal, _CacheName) -> not_loaded(?LINE).
 
 sasl_client_new(_Service, _Host, _Principal, _User) -> not_loaded(?LINE).
 
@@ -334,3 +343,6 @@ not_loaded(Line) ->
             )
         ]}
     ).
+
+ccname() ->
+    "MEMORY:krb5cc_" ++ atom_to_list(node()).

--- a/src/sasl_auth.erl
+++ b/src/sasl_auth.erl
@@ -165,12 +165,13 @@ init() ->
 -spec kinit(keytab_path(), principal()) ->
     ok | {error, {binary(), integer(), binary()}}.
 kinit(KeyTabPath, Principal) ->
-    Ccname = ccname(),
-    kinit(KeyTabPath, Principal, Ccname).
+    kinit(KeyTabPath, Principal, <<>>).
 
-%% @doc Initialize credentials from a keytab file and principal.
-%% The CCname is provided for application's flexibility to decide
+%% @hidden Initialize credentials from a keytab file and principal.
+%% The argument CCname is provided for application's flexibility to decide
 %% which credentials cache type or name to use.
+%% When set to empty string, the default cache name `MEMORY:krb5cc_sasl_auth'
+%% is used.
 %% e.g. `FILE:/tmp/krb5cc_mycache' or `MEMORY:krbcc5_mycache'
 %%
 %% CAUTION: Changing credentials cache name at runtime is not tested!
@@ -356,6 +357,3 @@ not_loaded(Line) ->
             )
         ]}
     ).
-
-ccname() ->
-    "MEMORY:krb5cc_" ++ atom_to_list(node()).


### PR DESCRIPTION
Hopefully fixes #26, but not 100% sure because I cannot reproduce it.

The idea is to:
- Change to use `MEMORY` type cache by default (because the reported error is seemingly related to file system/hard drive)
- Allow caller to specify cache type and name. e.g. `kinit(KeyTab, Principal, "FILE:/tmp/my_cc_name")`. This should provide flexibility at application level. 